### PR TITLE
Display world map on canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <title>MMO Client</title>
-    <link rel="preload" as="image" href="/world.jpg">
+    <link rel="preload" as="image" href="world.jpg">
     <link rel="stylesheet" href="/styles.css">
   </head>
   <body>
@@ -17,9 +17,8 @@
 
         // Size the canvas to fill the window (CSS pixels -> device pixels for crispness)
         function resizeCanvasToDisplaySize() {
-          const dpr = window.devicePixelRatio || 1;
-          const displayWidth = Math.floor(window.innerWidth * dpr);
-          const displayHeight = Math.floor(window.innerHeight * dpr);
+          const displayWidth = Math.floor(window.innerWidth);
+          const displayHeight = Math.floor(window.innerHeight);
           if (canvas.width !== displayWidth || canvas.height !== displayHeight) {
             canvas.width = displayWidth;
             canvas.height = displayHeight;
@@ -31,7 +30,7 @@
         }
 
         const worldImage = new Image();
-        worldImage.src = '/world.jpg';
+        worldImage.src = 'world.jpg';
         worldImage.decoding = 'async';
         worldImage.addEventListener('load', () => {
           draw();


### PR DESCRIPTION
Remove DPR scaling for canvas dimensions and use relative image paths to display the world map at its actual size.

---
<a href="https://cursor.com/background-agent?bcId=bc-82a0c7bc-70c0-493c-bc4a-1cfba02ebc6c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-82a0c7bc-70c0-493c-bc4a-1cfba02ebc6c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

